### PR TITLE
Do not add spaces to prefix/suffix

### DIFF
--- a/vis-commentary.lua
+++ b/vis-commentary.lua
@@ -51,10 +51,9 @@ local function pesc(str)
 end
 
 local function comment_line(lines, lnum, prefix, suffix)
-    if suffix ~= "" then suffix = " " .. suffix end
     lines[lnum] = string.gsub(lines[lnum],
                               "(%s*)(.*)",
-                              "%1" .. pesc(prefix) .. " %2" .. pesc(suffix))
+                              "%1" .. pesc(prefix) .. "%2" .. pesc(suffix))
 end
 
 local function uncomment_line(lines, lnum, prefix, suffix)


### PR DESCRIPTION
Adding then removing a comment block left a trailing space on the line.
While I originally changed the code to remove that space, I decided
it was better to make as few changes as possible to the code and not
assume that we put a space there as we could be removing a comment
that was put there manually.