### PR TITLE
Add support for multiple cursors

### DIFF
--- a/vis-commentary.lua
+++ b/vis-commentary.lua
@@ -123,6 +123,7 @@ end, "Toggle comment on a the current line")
 local function visual_f(i)
     return function()
         local win = vis.win
+        local lines = win.file.lines
 
         local comment = comment_string[win.syntax]
         if not comment then return end
@@ -141,7 +142,6 @@ local function visual_f(i)
                 sel.pos = r.finish
                 local b = sel.line - i
 
-                local lines = win.file.lines
                 block_comment(lines, a, b, prefix, suffix)
 
                 sel:to(lnum, col)     -- restore cursor position


### PR DESCRIPTION
# Solves

1. Spawn two or more cursors on different lines.
2. Try to comment them either with `gcc` or `gc` methods.

-> only one line will be commented.

# How it works

Every selection (line, block) with a cursor is treated separately. For example, if there are three lines with cursors, one of which is commented, on `gcc` it will be uncommented, and the other two will be commented.