### PR TITLE
init.lua: add (o)caml support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -22,7 +22,7 @@ local comment_string = {
     scala='//', scheme=';', smalltalk='"|"', sml='(*)', snobol4='#', sql='#',
     tcl='#', tex='%', text='', toml='#', vala='//', vb='\'', vbscript='\'',
     verilog='//', vhdl='--', wsf='<!--|-->', xml='<!--|-->', yaml='#', zig='//',
-    nim='#', julia='#', rpmspec='#'
+    nim='#', julia='#', rpmspec='#', caml='(*|*)'
 }
 
 -- escape all magic characters with a '%'


### PR DESCRIPTION
This PR adds support for OCaml comments. Comment_string corresponds to the caml.lua lexer.